### PR TITLE
Corrected swizzled method implementations

### DIFF
--- a/CoconutKit/Sources/View/UITextField+HLSExtensions.m
+++ b/CoconutKit/Sources/View/UITextField+HLSExtensions.m
@@ -13,12 +13,12 @@
 static UITextField *s_currentTextField = nil;           // weak ref to the current first responder
 
 // Original implementation of the methods we swizzle
-static void (*s_UITextField__becomeFirstResponder_Imp)(id, SEL) = NULL;
-static void (*s_UITextField__resignFirstResponder_Imp)(id, SEL) = NULL;
+static BOOL (*s_UITextField__becomeFirstResponder_Imp)(id, SEL) = NULL;
+static BOOL (*s_UITextField__resignFirstResponder_Imp)(id, SEL) = NULL;
 
 // Swizzled method implementations
-static void swizzled_UITextField__becomeFirstResponder_Imp(UITextField *self, SEL _cmd);
-static void swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SEL _cmd);
+static BOOL swizzled_UITextField__becomeFirstResponder_Imp(UITextField *self, SEL _cmd);
+static BOOL swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SEL _cmd);
 
 @implementation UITextField (HLSExtensions)
 
@@ -26,10 +26,10 @@ static void swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SE
 
 + (void)load
 {
-    s_UITextField__becomeFirstResponder_Imp = (void (*)(id, SEL))HLSSwizzleSelector(self, 
+    s_UITextField__becomeFirstResponder_Imp = (BOOL (*)(id, SEL))HLSSwizzleSelector(self,
                                                                                     @selector(becomeFirstResponder), 
                                                                                     (IMP)swizzled_UITextField__becomeFirstResponder_Imp);
-    s_UITextField__resignFirstResponder_Imp = (void (*)(id, SEL))HLSSwizzleSelector(self, 
+    s_UITextField__resignFirstResponder_Imp = (BOOL (*)(id, SEL))HLSSwizzleSelector(self,
                                                                                     @selector(resignFirstResponder), 
                                                                                     (IMP)swizzled_UITextField__resignFirstResponder_Imp);
 }
@@ -43,16 +43,27 @@ static void swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SE
 
 #pragma mark Swizzled method implementations
 
-static void swizzled_UITextField__becomeFirstResponder_Imp(UITextField *self, SEL _cmd)
+static BOOL swizzled_UITextField__becomeFirstResponder_Imp(UITextField *self, SEL _cmd)
 {
     s_currentTextField = self;
-    (*s_UITextField__becomeFirstResponder_Imp)(self, _cmd);
+    return (*s_UITextField__becomeFirstResponder_Imp)(self, _cmd);
 }
 
-static void swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SEL _cmd)
+static BOOL swizzled_UITextField__resignFirstResponder_Imp(UITextField *self, SEL _cmd)
 {
-    (*s_UITextField__resignFirstResponder_Imp)(self, _cmd);
+    BOOL retval = (*s_UITextField__resignFirstResponder_Imp)(self, _cmd);
     if (self == s_currentTextField) {
         s_currentTextField = nil;
     }
+    return retval;
 }
+
+@interface UITextFieldHLSExtensions_Linker
++ (void)link;
+@end
+
+
+@implementation UITextFieldHLSExtensions_Linker
++ (void)link {}
+@end
+

--- a/CoconutKit/Sources/View/UITextView+HLSExtensions.m
+++ b/CoconutKit/Sources/View/UITextView+HLSExtensions.m
@@ -13,12 +13,12 @@
 static UITextView *s_currentTextView = nil;           // weak ref to the current first responder
 
 // Original implementation of the methods we swizzle
-static void (*s_UITextView__becomeFirstResponder_Imp)(id, SEL) = NULL;
-static void (*s_UITextView__resignFirstResponder_Imp)(id, SEL) = NULL;
+static BOOL (*s_UITextView__becomeFirstResponder_Imp)(id, SEL) = NULL;
+static BOOL (*s_UITextView__resignFirstResponder_Imp)(id, SEL) = NULL;
 
 // Swizzled method implementations
-static void swizzled_UITextView__becomeFirstResponder_Imp(UITextView *self, SEL _cmd);
-static void swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL _cmd);
+static BOOL swizzled_UITextView__becomeFirstResponder_Imp(UITextView *self, SEL _cmd);
+static BOOL swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL _cmd);
 
 @implementation UITextView (HLSExtensions)
 
@@ -37,10 +37,10 @@ static void swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL 
 
 + (void)load
 {
-    s_UITextView__becomeFirstResponder_Imp = (void (*)(id, SEL))HLSSwizzleSelector(self, 
+    s_UITextView__becomeFirstResponder_Imp = (BOOL (*)(id, SEL))HLSSwizzleSelector(self, 
                                                                                    @selector(becomeFirstResponder), 
                                                                                    (IMP)swizzled_UITextView__becomeFirstResponder_Imp);
-    s_UITextView__resignFirstResponder_Imp = (void (*)(id, SEL))HLSSwizzleSelector(self, 
+    s_UITextView__resignFirstResponder_Imp = (BOOL (*)(id, SEL))HLSSwizzleSelector(self, 
                                                                                    @selector(resignFirstResponder), 
                                                                                    (IMP)swizzled_UITextView__resignFirstResponder_Imp);
 }
@@ -49,17 +49,18 @@ static void swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL 
 
 #pragma mark Swizzled method implementations
 
-static void swizzled_UITextView__becomeFirstResponder_Imp(UITextView *self, SEL _cmd)
+static BOOL swizzled_UITextView__becomeFirstResponder_Imp(UITextView *self, SEL _cmd)
 {
     s_currentTextView = self;
-    (*s_UITextView__becomeFirstResponder_Imp)(self, _cmd);
+    return (*s_UITextView__becomeFirstResponder_Imp)(self, _cmd);
 }
 
-static void swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL _cmd)
+static BOOL swizzled_UITextView__resignFirstResponder_Imp(UITextView *self, SEL _cmd)
 {
-    (*s_UITextView__resignFirstResponder_Imp)(self, _cmd);
+    BOOL retval = (*s_UITextView__resignFirstResponder_Imp)(self, _cmd);
     if (self == s_currentTextView) {
         s_currentTextView = nil;
     }
+	return retval;
 }
 


### PR DESCRIPTION
Incorrect implementation leads to bugs related to changing responders. (ex. focus switched only on second user tap)
